### PR TITLE
Enhancement : include last commit hash in PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/commit_hash.tex

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+function add_commit_hash() {
+  commit_hash=$(git rev-parse --short HEAD)
+  commit_date=$(git show -s --format=%ci HEAD | cut -d' ' -f1)
+  echo "\\newcommand{\\commitHash}{\\href{https://github.com/fnieri/LanguagesAndTranslatorsTP/tree/$commit_hash}{$commit_hash}}" > commit_hash.tex
+  echo "\\newcommand{\\commitDate}{$commit_date}" >> commit_hash.tex
+}
+
+add_commit_hash
 mkdir "out"
 pdflatex -output-directory=./out main.tex
 # Compile twice to get table of contents

--- a/main.tex
+++ b/main.tex
@@ -52,9 +52,11 @@ breaklines = true, %% enable line breaking
 numberstyle = \tiny,
 }
 
+\input{commit_hash.tex}
+
 \title{Language And Translators - TP Correction}
 \author{Francesco Nieri}
-\date{June 2024}
+\date{June 2024 (last update: \commitHash on \commitDate)}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
This feature indicates what was the last commit (with commit date) when the PDF was compiled. This make it easier to know whether or not your PDF is up to date.

Here is how this work : 

- The compile script create a file `commit_hash.tex` which contains two new commands to obtain commit (short) hash and date via `git rev-parse` and `git show`.
- `commit_hash.tex` is included in the `main.tex`
- `commit_hash.tex` is added to the ignore file so one doesn't needs to add / restore it before committing

LMK if this is good for you