### PR TITLE
Fix typo

### DIFF
--- a/TP3/2_1b.tex
+++ b/TP3/2_1b.tex
@@ -7,7 +7,7 @@ It is LL(1) as:
       \begin{cases}
         la(R' \rightarrow +TR') = \{+\$ \\
         la(R' \rightarrow TR') = \{(, a, b\} \\
-        la(R' \rightarrow \cdot TR') = \{\cdot\} \\
+        la(R' \rightarrow \cdot R') = \{\cdot\} \\
         la(R' \rightarrow \varepsilon) = \{ \varepsilon, )\} \\
     \end{cases}  
     \end{equation}


### PR DESCRIPTION
There is no rule doing R' -> \cdot TR'